### PR TITLE
CC-1660: Requested changes to HIT 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ucb-cspace/cspace-ui",
-  "version": "4.0.0-ucb.4.d7",
+  "version": "4.0.0-ucb.4.d8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ucb-cspace/cspace-ui",
-  "version": "4.0.0-ucb.4.d7",
+  "version": "4.0.0-ucb.4.d8",
   "description": "CollectionSpace user interface for browsers",
   "author": "Ray Lee <ray.lee@lyrasis.org>",
   "license": "ECL-2.0",

--- a/src/plugins/recordTypes/hit/fields.js
+++ b/src/plugins/recordTypes/hit/fields.js
@@ -496,7 +496,6 @@ export default (configContext) => {
             },
           },
         },
-
         fieldCollectionGroupList: {
           [config]: {
             view: {
@@ -505,12 +504,6 @@ export default (configContext) => {
           },
           fieldCollectionGroup: {
             [config]: {
-              messages: defineMessages({
-                name: {
-                  id: 'field.hits_common.fieldCollectionGroup.name',
-                  defaultMessage: 'Field Collection Information',
-                },
-              }),
               repeating: true,
               view: {
                 type: CompoundInput,
@@ -524,8 +517,7 @@ export default (configContext) => {
               },
               fieldCollectionDate: {
                 [config]: {
-                  dataType: DATA_TYPE_DATE,
-                  messages: defineMessages({
+                  messages: defineMessages( {
                     name: {
                       id: 'field.hits_common.fieldCollectionDate.name',
                       defaultMessage: 'Field collection date',
@@ -533,7 +525,7 @@ export default (configContext) => {
                   }),
                   repeating: true,
                   view: {
-                    type: DateInput,
+                    type: TextInput,
                   },
                 },
               },

--- a/src/plugins/recordTypes/hit/fields.js
+++ b/src/plugins/recordTypes/hit/fields.js
@@ -86,7 +86,7 @@ export default (configContext) => {
               messages: defineMessages({
                 name: {
                   id: 'field.hits_common.hitDepositorGroup.name',
-                  defaultMessage: 'Depositor',
+                  defaultMessage: 'Name',
                 },
               }),
               repeating: true,
@@ -102,11 +102,11 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.hits_common.depositor.fullName',
-                    defaultMessage: 'Depositor',
+                    defaultMessage: 'Depositor name',
                   },
                   name: {
                     id: 'field.hits_common.depositor.name',
-                    defaultMessage: 'Depositor',
+                    defaultMessage: 'Name',
                   },
                 }),
                 view: {
@@ -126,7 +126,7 @@ export default (configContext) => {
                   },
                   name: {
                     id: 'field.hits_common.depositorContact.name',
-                    defaultMessage: 'Depositor contact',
+                    defaultMessage: 'Contact',
                   },
                 }),
                 view: {
@@ -166,7 +166,7 @@ export default (configContext) => {
                   },
                   name: {
                     id: 'field.hits_common.depositorNote.name',
-                    defaultMessage: 'Depositor note',
+                    defaultMessage: 'Note',
                   },
                 }),
                 view: {
@@ -291,7 +291,7 @@ export default (configContext) => {
                   },
                   name: {
                     id: 'field.hits_common.internalApprovalGroup.name',
-                    defaultMessage: 'Internal approval group',
+                    defaultMessage: 'Group',
                   },
                 }),
                 view: {
@@ -311,7 +311,7 @@ export default (configContext) => {
                   },
                   name: {
                     id: 'field.hits_common.internalApprovalIndividual.name',
-                    defaultMessage: 'Internal approval individual',
+                    defaultMessage: 'Individual',
                   },
                 }),
                 view: {
@@ -331,7 +331,7 @@ export default (configContext) => {
                   },
                   name: {
                     id: 'field.hits_common.internalApprovalStatus.name',
-                    defaultMessage: 'Internal approval status',
+                    defaultMessage: 'Status',
                   },
                 }),
                 view: {
@@ -351,7 +351,7 @@ export default (configContext) => {
                   },
                   name: {
                     id: 'field.hits_common.internalApprovalDate.name',
-                    defaultMessage: 'Internal approval date',
+                    defaultMessage: 'Date',
                   },
                 }),
                 view: {
@@ -364,7 +364,7 @@ export default (configContext) => {
                 messages: defineMessages({
                   fullName: {
                     id: 'field.hits_common.internalApprovalNote.fullName',
-                    defaultMessage: 'Internal approval note',
+                    defaultMessage: 'Note',
                   },
                   name: {
                     id: 'field.hits_common.internalApprovalNote.name',
@@ -409,7 +409,7 @@ export default (configContext) => {
                   },
                   name: {
                     id: 'field.hits_common.externalApprovalGroup.name',
-                    defaultMessage: 'External approval group',
+                    defaultMessage: 'Group',
                   },
                 }),
                 view: {
@@ -429,7 +429,7 @@ export default (configContext) => {
                   },
                   name: {
                     id: 'field.hits_common.externalApprovalIndividual.name',
-                    defaultMessage: 'External approval individual',
+                    defaultMessage: 'Individual',
                   },
                 }),
                 view: {
@@ -449,7 +449,7 @@ export default (configContext) => {
                   },
                   name: {
                     id: 'field.hits_common.externalApprovalStatus.name',
-                    defaultMessage: 'External approval status',
+                    defaultMessage: 'Status',
                   },
                 }),
                 view: {
@@ -469,7 +469,7 @@ export default (configContext) => {
                   },
                   name: {
                     id: 'field.hits_common.externalApprovalDate.name',
-                    defaultMessage: 'External approval date',
+                    defaultMessage: 'Date',
                   },
                 }),
                 view: {
@@ -517,6 +517,7 @@ export default (configContext) => {
               },
               fieldCollectionDate: {
                 [config]: {
+                  dataType: DATA_TYPE_DATE,
                   messages: defineMessages( {
                     name: {
                       id: 'field.hits_common.fieldCollectionDate.name',
@@ -525,7 +526,7 @@ export default (configContext) => {
                   }),
                   repeating: true,
                   view: {
-                    type: TextInput,
+                    type: DateInput,
                   },
                 },
               },
@@ -874,7 +875,7 @@ export default (configContext) => {
                   },
                   name: {
                     id: 'field.hits_common.correspondenceDate.name',
-                    defaultMessage: 'Correspondence date',
+                    defaultMessage: 'Date',
                   },
                 }),
                 view: {

--- a/src/plugins/recordTypes/hit/forms/default.jsx
+++ b/src/plugins/recordTypes/hit/forms/default.jsx
@@ -14,7 +14,6 @@ const template = (configContext) => {
 
   const {
     Field,
-    Subrecord,
   } = configContext.recordComponents;
 
   return (
@@ -79,34 +78,41 @@ const template = (configContext) => {
 
       <Panel name="fieldCollectionInfo" collapsible collapsed>
         <Field name="fieldCollectionGroupList">
-          <Field name="fieldCollectionGroup">
-            <Cols>
-              <Col>
-                <Field name="fieldCollectionDates" >
-                  <Field name="fieldCollectionDate" />
-                </Field>
-                <Field name="fieldCollectionMethods">
-                  <Field name="fieldCollectionMethod" />
-                </Field>
+            <Field name="fieldCollectionGroup">
+              <Panel>
+                <Cols>
+                  <Col>
+                    <Field name="fieldCollectionDates" >
+                      <Field name="fieldCollectionDate" />
+                    </Field>
+                  
+                    <Field name="fieldCollectionMethods">
+                      <Field name="fieldCollectionMethod" />
+                    </Field>
+                    
+                    <Field name="fieldCollectionPlaces" >
+                      <Field name="fieldCollectionPlace" />
+                    </Field>
+                    
+                    <Field name="fieldCollectionPlaceVerbatim" />
+                  </Col>
+                  <Col>
+                    <Field name="fieldCollectionNumber" />
+
+                    <Field name="fieldCollectionSources">
+                      <Field name="fieldCollectionSource" />
+                    </Field>
+
+                    <Field name="fieldCollectors">
+                      <Field name="fieldCollector" />
+                    </Field>
+                    <Field name="fieldCollectionEventNames">
+                      <Field name="fieldCollectionEventName" />
+                    </Field>
+                  </Col>
+                </Cols>
                 <Field name="fieldCollectionNote" />
-                <Field name="fieldCollectionNumber" />
-              </Col>
-              <Col>
-                <Field name="fieldCollectionPlaces" >
-                  <Field name="fieldCollectionPlace" />
-                </Field>
-                <Field name="fieldCollectionPlaceVerbatim" />
-                <Field name="fieldCollectionSources">
-                  <Field name="fieldCollectionSource" />
-                </Field>
-                <Field name="fieldCollectors">
-                  <Field name="fieldCollector" />
-                </Field>
-                <Field name="fieldCollectionEventNames">
-                  <Field name="fieldCollectionEventName" />
-                </Field>
-              </Col>
-            </Cols>
+            </Panel>
           </Field>
         </Field>
       </Panel>


### PR DESCRIPTION
- [X] Term lists [Fixed]
    - Term lists have a fixed alphabetical order when created using the application layer config. This order can be changed in the Tools > Term Lists menu, but this will be left for Michael to add manually
    - Richard and I will *not* be altering the values of the Contact type field. This will be left up to the user to do, since its the same list but with different values.
- [X] Field Collection Information
    - [X] The ordering of the fields on QA differs from the wireframes. 
    - [X]  The wireframe does not show Field collection date as a date field 
    - [X] The schema doesn't include Field Collection Place (verbatim)
        - [X] I double-checked the schema and this field exists in the first column right below “Field Collection place” under the information panel
- [X] Culture Care and Handling: Missing terms (will be in app layer)
